### PR TITLE
benchmark different crd count

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,8 @@ jobs:
   bench:
     strategy:
       matrix:
-        RESOURCES: [ 100, 500, 1000 ]
+        RESOURCES: [100, 500, 1000]
+        CRDS: [100, 500, 1000]
     runs-on:
       group: "Default Larger Runners"
       labels: ubuntu-latest-16-cores
@@ -31,6 +32,8 @@ jobs:
         run: make timoni-push
       - name: Install Flux
         run: make flux-up
+        env:
+          CRD_COUNT: ${{ matrix.CRDS }}
       - name: Install metrics-server
         run: timoni bundle apply -f timoni/bundles/flux-metrics.cue
       - name: Run kustomize install benchmark

--- a/scripts/crd_template.yaml
+++ b/scripts/crd_template.yaml
@@ -1,0 +1,33 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: exampleresources.CRD_COUNT.example.com
+spec:
+  group: CRD_COUNT.example.com
+  names:
+    kind: ExampleResource
+    listKind: ExampleResourceList
+    plural: exampleresources
+    singular: exampleresource
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                size:
+                  type: integer
+                  minimum: 1
+                  maximum: 10
+                color:
+                  type: string
+                  enum:
+                    - red
+                    - blue
+                    - green

--- a/scripts/flux-install.sh
+++ b/scripts/flux-install.sh
@@ -8,3 +8,4 @@ kubectl label node flux-worker role=flux --overwrite
 kubectl taint nodes flux-worker role=flux:NoSchedule --overwrite
 
 flux install --manifests $repo_root/manifests/install
+$repo_root/scripts/generate-crds.sh

--- a/scripts/generate-crds.sh
+++ b/scripts/generate-crds.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+repo_root=$(git rev-parse --show-toplevel)
+template_file="$repo_root/scripts/crd_template.yaml"
+tmpdir="${TMPDIR:-/tmp}"
+for ((i=1; i<=$CRD_COUNT; i++))
+do
+  crd_name="$i"
+  sed "s/CRD_COUNT/$crd_name/" $template_file > "$tmpdir/generated_crd_$i.yaml"
+  kubectl apply -f "$tmpdir/generated_crd_$i.yaml" > /dev/null
+done
+echo "Generated $crds CRDs"


### PR DESCRIPTION
### Description 

This is a benchmark test based on my conversation with @stefanprodan on Flux's Slack. 

The test automatically generate N amount of CRDs directly after installing flux. 

I am currently experiencing restarts with helm-controller. After testing [collecting profile logs](https://fluxcd.io/flux/gitops-toolkit/debugging/#collecting-a-profile), @stefanprodan suggested that the problem might be related to the amount of CRDs I have in my cluster. 

### Profile (partial logs)
```
(pprof) top10
Showing nodes accounting for 668.27MB, 89.98% of 742.69MB total
Dropped 280 nodes (cum <= 3.71MB)
Showing top 10 nodes out of 113
      flat  flat%   sum%        cum   cum%
  335.59MB 45.19% 45.19%   335.59MB 45.19%  reflect.New
  112.06MB 15.09% 60.28%   112.06MB 15.09%  google.golang.org/protobuf/internal/impl.consumeStringValidateUTF8
   82.07MB 11.05% 71.33%    82.07MB 11.05%  io.ReadAll
   41.01MB  5.52% 76.85%   105.53MB 14.21%  k8s.io/kube-openapi/pkg/util/proto.(*Definitions).parseKind
   20.50MB  2.76% 79.61%       29MB  3.91%  k8s.io/kube-openapi/pkg/util/proto.(*Definitions).parsePrimitive
   18.01MB  2.43% 82.03%    18.01MB  2.43%  github.com/go-openapi/swag.(*NameProvider).GetJSONNames
   17.50MB  2.36% 84.39%    33.01MB  4.44%  k8s.io/kube-openapi/pkg/util/proto.VendorExtensionToMap
      15MB  2.02% 86.41%       15MB  2.02%  google.golang.org/protobuf/internal/impl.consumeStringSliceValidateUTF8
   14.01MB  1.89% 88.30%    54.03MB  7.27%  k8s.io/kube-openapi/pkg/validation/spec.(*Schema).UnmarshalNextJSON
   12.51MB  1.68% 89.98%    12.51MB  1.68%  reflect.mapassign0
``` 

### CRDs and HR
```
k get crds | wc -l
109

k get hr -A | wc -l 
61
```

