### PR TITLE
Publish Kubernetes KinD node images for AMD46/ARM64

### DIFF
--- a/.github/workflows/build-kind.yaml
+++ b/.github/workflows/build-kind.yaml
@@ -52,3 +52,43 @@ jobs:
         run: |
           docker tag kindest/node:latest ghcr.io/fluxcd/kindest/node:${{ steps.prep.outputs.VERSION }}-amd64
           docker push ghcr.io/fluxcd/kindest/node:${{ steps.prep.outputs.VERSION }}-amd64
+  k8s-node-arm64:
+    # Hosted on Equinix
+    # Docs: https://github.com/fluxcd/flux2/tree/main/.github/runners
+    runs-on: [self-hosted, Linux, ARM64, equinix]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Prepare
+        id: prep
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if [[ -z "$VERSION" ]]; then
+            VERSION="v1.27.13"
+          fi
+          echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.x
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: kubernetes/kubernetes
+          ref: ${{ steps.prep.outputs.VERSION }}
+          path: kubernetes
+      - name: Build node image
+        run: |
+          cd $GITHUB_WORKSPACE/kubernetes
+          kind build node-image
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: fluxcdbot
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Push node image
+        run: |
+          docker tag kindest/node:latest ghcr.io/fluxcd/kindest/node:${{ steps.prep.outputs.VERSION }}-arm64
+          docker push ghcr.io/fluxcd/kindest/node:${{ steps.prep.outputs.VERSION }}-arm64

--- a/.github/workflows/build-kind.yaml
+++ b/.github/workflows/build-kind.yaml
@@ -1,0 +1,54 @@
+name: build-kind
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Kubernetes version'
+        default: 'v1.30.0'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  k8s-node-amd64:
+    runs-on:
+      group: "Default Larger Runners"
+      labels: ubuntu-latest-16-cores
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Prepare
+        id: prep
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if [[ -z "$VERSION" ]]; then
+            VERSION="v1.27.13"
+          fi
+          echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.22.x
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: kubernetes/kubernetes
+          ref: ${{ steps.prep.outputs.VERSION }}
+          path: kubernetes
+      - name: Build node image
+        run: |
+          cd $GITHUB_WORKSPACE/kubernetes
+          kind build node-image
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: fluxcdbot
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Push node image
+        run: |
+          docker tag kindest/node:latest ghcr.io/fluxcd/kindest/node:${{ steps.prep.outputs.VERSION }}-amd64
+          docker push ghcr.io/fluxcd/kindest/node:${{ steps.prep.outputs.VERSION }}-amd64


### PR DESCRIPTION
This PR adds a GitHub workflow for building and publishing KinD node images on [ghcr.io/fluxcd/kindest/node](https://github.com/fluxcd/flux-benchmark/pkgs/container/kindest%2Fnode) for a given Kubernetes git tag.

## Motivation

This allows us to run the Flux benchmarks and conformance tests for Kubernetes pre-releases and stable versions without depending on the official KinD images which lag behind upstream releases and don't contain alpha, beta and RC builds.

## Specifications

The KinD node images hosted on the FluxCD GitHub Container Registry are not multi-arch, instead we publish dedicated tags for each architecture in the format `<K8S-SEMVER>-<ARCH>`.

### AMD64 images

Image format: `ghcr.io/fluxcd/kindest/node:<K8S-SEMVER>-amd64`

Builder: ubuntu-latest-16-cores (GitHub hosted runner)

```sh
kind create cluster --image ghcr.io/fluxcd/kindest/node:v1.30.0-amd64
```

### ARM64 images

Image format: `ghcr.io/fluxcd/kindest/node:<K8S-SEMVER>-arm64`

Builder: c3.large.arm64 (Equinix Metal self-hosted runner)

```sh
kind create cluster --image ghcr.io/fluxcd/kindest/node:v1.30.0-arm64
```